### PR TITLE
Fix outline links to individual chiasms

### DIFF
--- a/client/explanation/Outline.html
+++ b/client/explanation/Outline.html
@@ -14,7 +14,7 @@
 		</span>
 
 		<strong>
-			<a href="./#{{section.anchor}}">
+			<a href="./text?chiasm={{section.anchor}}">
 				{{sectionLabel(section)}}:
 			</a>
 		</strong>


### PR DESCRIPTION
https://revelation.biblicalblueprints.org/structure/explanation#the-pattern

Currently the chiasm links don't work.

This code is not tested...